### PR TITLE
proxy-setup

### DIFF
--- a/defaultdev.env
+++ b/defaultdev.env
@@ -1,0 +1,4 @@
+export PROXY_LISTEN_PORT=8080
+export PROXY_HOST=localhost
+export SERVER_LISTEN_PORT=9090
+export SERVER_HOST=localhost

--- a/proxy/envoy.yaml.in
+++ b/proxy/envoy.yaml.in
@@ -1,0 +1,43 @@
+static_resources:
+  listeners:
+  - name: listener0
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: ${PROXY_LISTEN_PORT:-ENV_SUBST_ERROR}
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains:
+              - "*"
+              routes:
+              - match: 
+                  prefix: "/"
+                route: 
+                  cluster: checkers_service
+          http_filters:
+          - name: envoy.filters.http.grpc_web
+          - name: envoy.filters.http.router
+  clusters:
+  - name: checkers_service
+    connect_timeout: 0.25s
+    type: logical_dns
+    http2_protocol_options:
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: cluster_0
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: ${SERVER_HOST:-ENV_SUBST_ERROR}
+                    port_value: ${SERVER_LISTEN_PORT:-ENV_SUBST_ERROR}

--- a/proxy/run-proxy.sh
+++ b/proxy/run-proxy.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+tempfile="$(mktemp).yaml"
+sed_program='s/"/\\"/g'
+eval "echo \"$(cat $(dirname $0)/envoy.yaml.in | sed $sed_program)\"" > $tempfile
+envoy -c $tempfile
+rm $tempfile

--- a/server/README.md
+++ b/server/README.md
@@ -2,5 +2,6 @@ To run:
 ```
 $ source checkers/defaultdev.env
 $ cd checkers/server
+$ go generate
 $ go run .
 ```

--- a/server/README.md
+++ b/server/README.md
@@ -1,4 +1,6 @@
-To build:
+To run:
 ```
-$ go generate
-$ go build
+$ source checkers/defaultdev.env
+$ cd checkers/server
+$ go run .
+```

--- a/server/main.go
+++ b/server/main.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
+	"strconv"
 
 	gppb "github.com/MettyS/checkers/server/generated"
 	"google.golang.org/grpc"
@@ -32,7 +34,11 @@ func (s *server) MakeMoves(ctx context.Context, req *gppb.MoveRequest) *gppb.Mov
 // rpc BoardUpdateSubscription(BoardSubscriptionRequest) returns (stream BoardUpdate) {}
 
 func main() {
-	lis, err := net.Listen("tcp", ":9000")
+	port, err := strconv.Atoi(os.Getenv("SERVER_LISTEN_PORT"))
+	if err != nil {
+		log.Fatalln("SERVER_LISTEN_PORT env var is required")
+	}
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%v", port))
 
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
@@ -40,8 +46,8 @@ func main() {
 
 	checkersServer := grpc.NewServer()
 
-	s := server{}
-	gppb.RegisterGameplayServiceServer(checkersServer, &s)
+	//s := server{}
+	//gppb.RegisterGameplayServiceServer(checkersServer, &s)
 
 	if err := checkersServer.Serve(lis); err != nil {
 		log.Fatalf("failed to serve: %s", err)


### PR DESCRIPTION
Added a defaultdev.env that must be sourced in a shell before running
proxy/run-proxy.sh.  This dotenv file does not have any secrets, so I think it's fine
to commit and version.  The server implementation was also updated to
read in the correct listening port from the environment.